### PR TITLE
use /usr/bin/env to find the shell instead of a hardcoded path

### DIFF
--- a/tmobile_plot.sh
+++ b/tmobile_plot.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/bash
+#!/usr/bin/env bash
 
 
 while getopts d:lho: flag


### PR DESCRIPTION
This is generally more compatible with other distributions than a hardcoded path to /usr/bin/bash or /bin/bash