### PR TITLE
Use outfile to specify the graph output

### DIFF
--- a/tmobile_plot.sh
+++ b/tmobile_plot.sh
@@ -11,8 +11,8 @@ do
             echo "  -h        Show help"
             echo "  -l        Only log the data. Do not plot"
             echo "  -d file   Set datafile to 'file'. Default is '/tmp/.data.csv'"
-            echo "  -o file   Set graph output to 'file'. Default is 'datafile'.pdf with any "
-            echo "            extensions removed"
+            echo "  -o file   Set graph output to 'file'. Default is datafile with any "
+            echo "            extensions replaced with the current output type (default pdf)"
             exit 0;;
     esac
 done
@@ -25,7 +25,7 @@ fi
 
 if [[ $_outfile == "" ]]; then
   _outfile=$(echo "$datafile" | cut -f 1 -d '.')
-  outfile=${_outfile}.pdf
+  outfile=${_outfile}
 else
   outfile=${_outfile}
 fi
@@ -41,10 +41,10 @@ fi
 
 gnuplot -p <<-END
   set terminal pdfcairo enhanced color font ",10";
-  set output 'data.pdf';
+  set output '${outfile}.pdf';
 
   #set terminal pngcairo enhanced size 1024,768
-  #set output 'data.png';
+  #set output '${outfile}.png';
 
   set grid xtics back lc rgb '#808080' lt 0 lw 1
   set grid ytics back lc rgb '#808080' lt 0 lw 1


### PR DESCRIPTION
as it is -o is ignored because 'data.pdf' is hardcoded into the gnuplot input. This patch uses the $outfile variable as it should be used in that place. I also dropped the extension from it so that it could be used to provide a path for other output formats(png) at the same time.